### PR TITLE
Grubb refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.platform/local

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -12,7 +12,7 @@ type: 'python:3.5'
 # The build-time dependencies of the app.
 dependencies:
     python:
-       uwsgi: '*'
+       gunicorn: '*'
 
 # The relationships of the application with services or other applications.
 #
@@ -30,7 +30,7 @@ web:
         socket_family: unix
     # Commands are run once after deployment to start the application process.
     commands:
-        start: "uwsgi --ini conf/uwsgi.ini"
+        start: "gunicorn -w 4 -b unix:$SOCKET myapp.wsgi:application"
 
 # The size of the persistent disk of the application (in MB).
 disk: 512

--- a/.platform/local/project.yaml
+++ b/.platform/local/project.yaml
@@ -1,2 +1,0 @@
-id: dbp2m6bw7krkq
-host: eu.platform.sh

--- a/conf/uwsgi.ini
+++ b/conf/uwsgi.ini
@@ -1,7 +1,0 @@
-[uwsgi]
-# UNIX socket to use to talk HTTP with NGINX
-socket = $(SOCKET)
-protocol = http
-
-# the WSGI entry point
-module = myapp.wsgi:application


### PR DESCRIPTION
Hello.  This change removes the uwsgi dependency in favor of gunicorn, which has the benefit of removing the need for the `conf/` directory => fewer apparent moving pieces.

It also adds a `.gitignore` and removes the `.platform/local` directory that had slipped into this repo.
