### PR TITLE
Disable pip version check

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -40,5 +40,5 @@ hooks:
   # The build hook runs before the application is deployed, and is useful for
   # assembling the codebase.
   build: |
-    pip install -r requirements.txt
+    pip install --disable-pip-version-check --requirement requirements.txt
 


### PR DESCRIPTION
Just because this irritated me:
```
        You are using pip version 8.1.2, however version 9.0.1 is available.
        You should consider upgrading via the 'pip install --upgrade pip' command.
```